### PR TITLE
prepare release spectrum-2.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ WebJar for Spectrum
 
 More info: http://webjars.org
 
-Upstream: https://github.com/bgrins/spectrum
+Upstream: https://github.com/seballot/spectrum

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>spectrum</artifactId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>2.0.5</version>
     <name>Spectrum</name>
     <description>WebJar for Spectrum</description>
     <url>http://webjars.org</url>
@@ -46,8 +46,8 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>1.7.0</upstream.version>
-        <upstream.url>https://github.com/bgrins/spectrum/archive</upstream.url>
+        <upstream.version>2.0.5</upstream.version>
+        <upstream.url>https://github.com/seballot/spectrum/archive</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
             {


### PR DESCRIPTION
Use your pom to build a spectrum 2.0.5 webjars.
Also change readme : seballot's spectrum project is a fork of the original one.
The original one left to 1.8 in 2016 whereas seballot's one still maintains.
If you can add it in webjars library that will be awesome.

Thanks man ! :)